### PR TITLE
Compatibility for Win10, PEP8ing

### DIFF
--- a/espresso.py
+++ b/espresso.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-'''
+"""
 Copyright 2013 Benn Snyder
 Espresso keeps your computer awake from the system tray.
 Espresso is freely available under the terms of the GNU Public License, version 3.  The license appears in GPLv3.txt.
-'''
+"""
 
 import os
 import sys
@@ -13,71 +13,71 @@ from PyQt5 import QtCore, QtGui, QtSvg, QtWidgets
 
 
 class TrayIcon(QtWidgets.QSystemTrayIcon):
-	def __init__(self, inhibitor, parent):
-		super().__init__(parent)
+    def __init__(self, inhibitor, parent):
+        super().__init__(parent)
 
-		self.ICON_EMPTY_CUP     = QtGui.QIcon(os.path.join(os.path.dirname(__file__), "Empty_Cup.svg"))
-		self.ICON_FULL_CUP      = QtGui.QIcon(os.path.join(os.path.dirname(__file__), "Full_Cup.svg"))
-		self.ICON_CRYSTAL_CLOCK = QtGui.QIcon(os.path.join(os.path.dirname(__file__), "Crystal_Clock.svg"))
-		self.ICON_CLOSE         = self.parent().style().standardIcon(QtWidgets.QStyle.SP_DialogCloseButton)
+        self.ICON_EMPTY_CUP = QtGui.QIcon(os.path.join(os.path.dirname(__file__), "Empty_Cup.svg"))
+        self.ICON_FULL_CUP = QtGui.QIcon(os.path.join(os.path.dirname(__file__), "Full_Cup.svg"))
+        self.ICON_CRYSTAL_CLOCK = QtGui.QIcon(os.path.join(os.path.dirname(__file__), "Crystal_Clock.svg"))
+        self.ICON_CLOSE = self.parent().style().standardIcon(QtWidgets.QStyle.SP_DialogCloseButton)
 
-		self.inhibitor = inhibitor
-		self.timer = Timer(0, self.Event) # default timer never runs
-		self.UnInhibit()
-		self.setToolTip("Espresso - click to toggle, middle-click to quit")
-		self.setContextMenu(self.BuildMenu())
-		self.activated.connect(self.Event)
+        self.inhibitor = inhibitor
+        self.timer = Timer(0, self.Event)  # default timer never runs
+        self.UnInhibit()
+        self.setToolTip("Espresso - click to toggle, middle-click to quit")
+        self.setContextMenu(self.BuildMenu())
+        self.activated.connect(self.Event)
 
-	def BuildMenu(self):
-		menu = QtWidgets.QMenu()
+    def BuildMenu(self):
+        menu = QtWidgets.QMenu()
 
-		inhibit_menu = menu.addMenu(self.ICON_CRYSTAL_CLOCK, "Inhibit for")
-		for minutes in [1, 5, 10, 15, 30]:
-			suffix = "s" if minutes > 1 else ""
-			inhibit_menu.addAction(str(minutes)+" minute"+suffix).triggered.connect(lambda m = minutes : self.Inhibit(m))
-		for hours in [1, 2, 5]:
-			suffix = "s" if hours > 1 else ""
-			inhibit_menu.addAction(str(hours)+" hour"+suffix).triggered.connect(lambda m = hours*60 : self.Inhibit(m))
-		inhibit_menu.addAction("Indefinitely").triggered.connect(self.Inhibit)
+        inhibit_menu = menu.addMenu(self.ICON_CRYSTAL_CLOCK, "Inhibit for")
+        for minutes in [1, 5, 10, 15, 30]:
+            suffix = "s" if minutes > 1 else ""
+            inhibit_menu.addAction(str(minutes)+" minute"+suffix).triggered.connect(lambda m=minutes: self.Inhibit(m))
+        for hours in [1, 2, 5]:
+            suffix = "s" if hours > 1 else ""
+            inhibit_menu.addAction(str(hours)+" hour"+suffix).triggered.connect(lambda m=hours*60: self.Inhibit(m))
+        inhibit_menu.addAction("Indefinitely").triggered.connect(self.Inhibit)
 
-		menu.addAction(self.ICON_CLOSE, "Quit").triggered.connect(self.Quit)
-		return menu
+        menu.addAction(self.ICON_CLOSE, "Quit").triggered.connect(self.Quit)
+        return menu
 
-	def Event(self, reason):
-		if reason == QtWidgets.QSystemTrayIcon.Trigger:
-			if not self.inhibitor.Inhibited:
-				self.Inhibit()
-			else:
-				self.UnInhibit()
-		elif reason == QtWidgets.QSystemTrayIcon.MiddleClick:
-			self.Quit()
+    def Event(self, reason):
+        if reason == QtWidgets.QSystemTrayIcon.Trigger:
+            if not self.inhibitor.Inhibited:
+                self.Inhibit()
+            else:
+                self.UnInhibit()
+        elif reason == QtWidgets.QSystemTrayIcon.MiddleClick:
+            self.Quit()
 
-	def Inhibit(self, timeout_minutes = None):
-		self.timer.cancel()
-		if timeout_minutes is not None:
-			self.timer = Timer(timeout_minutes*60, self.UnInhibit)
-			self.timer.start()
-		self.setIcon(self.ICON_FULL_CUP)
-		self.inhibitor.Inhibit()
+    def Inhibit(self, timeout_minutes=None):
+        self.timer.cancel()
+        if timeout_minutes is not None:
+            self.timer = Timer(timeout_minutes*60, self.UnInhibit)
+            self.timer.start()
+        self.setIcon(self.ICON_FULL_CUP)
+        self.inhibitor.Inhibit()
 
-	def UnInhibit(self):
-		self.timer.cancel()
-		self.setIcon(self.ICON_EMPTY_CUP)
-		self.inhibitor.UnInhibit()
+    def UnInhibit(self):
+        self.timer.cancel()
+        self.setIcon(self.ICON_EMPTY_CUP)
+        self.inhibitor.UnInhibit()
 
-	def Quit(self):
-		self.UnInhibit()
-		self.deleteLater() # prevents PyQt4 segfault
-		self.parent().quit()
+    def Quit(self):
+        self.UnInhibit()
+        self.deleteLater()  # prevents PyQt4 segfault
+        self.parent().quit()
 
 
 if __name__ == "__main__":
-	import inhibitors
+    import inhibitors
 
-	app = QtWidgets.QApplication(sys.argv)
-	if not QtWidgets.QSystemTrayIcon.isSystemTrayAvailable():
-		QtGui.QMessageBox.critical(None, QtCore.QObject.tr(app, "Espresso"), QtCore.QObject.tr(app, "No system tray available"))
-		sys.exit(1)
-	icon = TrayIcon(inhibitors.AutoSelect(), app);
-	icon.show()
-	sys.exit(app.exec_())
+    app = QtWidgets.QApplication(sys.argv)
+    if not QtWidgets.QSystemTrayIcon.isSystemTrayAvailable():
+        QtGui.QMessageBox.critical(None, QtCore.QObject.tr(app, "Espresso"), QtCore.QObject.tr(app, "No system tray available"))
+        sys.exit(1)
+    icon = TrayIcon(inhibitors.AutoSelect(), app)
+    icon.show()
+    sys.exit(app.exec_())

--- a/inhibitors.py
+++ b/inhibitors.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-'''
+"""
 Copyright 2013 Benn Snyder
 Espresso keeps your computer awake from the system tray.
 Espresso is freely available under the terms of the GNU Public License, version 3.  The license appears in GPLv3.txt.
-'''
+"""
 
 import sys
 import platform
@@ -12,102 +12,106 @@ from abc import ABCMeta, abstractmethod
 
 
 def AutoSelect():
-	if platform.system() == "Linux":
-		return DBusInhibitor()
-	elif platform.system() == "Windows" and sys.getwindowsversion().build >= 7601:
-		return WinInhibitor()
-	else:
-		raise NotImplementedError("Platform not supported")
+    if platform.system() == "Linux":
+        return DBusInhibitor()
+    elif platform.system() == "Windows" and sys.getwindowsversion().build >= 7601:
+        return WinInhibitor()
+    else:
+        raise NotImplementedError("Platform not supported")
 
-# Implementations need only implement the methods marked with the `@abstractmethod` decorator and make sure `self.inhibited` is `None` only when not inhibited.
+
+# Implementations need only implement the methods marked with the `@abstractmethod` decorator and
+# make sure `self.inhibited` is `None` only when not inhibited.
 class SleepInhibitor(metaclass=ABCMeta):
-	"""
-	A SleepInhibitor implementation can be used to keep a machine awake in one of two ways.
-	
-	Explicitly:
-		inhibitor = ConcreteInhibitor()
-		inhibitor.Inhibit()
-		# AWAKE
-		inhibitor.UnInhibit() # or inhibitor.Toggle()
-		
-	In a `with` statement:
-		with ConcreteInhibitor() as inhibitor:
-			# AWAKE
-	"""
-	
-	def __init__(self):
-		self.inhibited = None # Attention Children: set to None when not inhibited
-	
-	def __del__(self):
-		self.UnInhibit()
-		
-	def __enter__(self):
-		self.Inhibit()
-		return self
-	
-	def __exit__(self, type, value, traceback):
-		self.UnInhibit()
-	
-	@property
-	def Inhibited(self):
-		return self.inhibited is not None
-	
-	def Toggle(self):
-		if not self.Inhibited:
-			self.Inhibit()
-		else:
-			self.UnInhibit()
-	
-	@abstractmethod
-	def Inhibit(self):
-		pass
-	
-	@abstractmethod
-	def UnInhibit(self):
-		pass
+    """
+    A SleepInhibitor implementation can be used to keep a machine awake in one of two ways.
+
+    Explicitly:
+        inhibitor = ConcreteInhibitor()
+        inhibitor.Inhibit()
+        # AWAKE
+        inhibitor.UnInhibit() # or inhibitor.Toggle()
+
+    In a `with` statement:
+        with ConcreteInhibitor() as inhibitor:
+            # AWAKE
+    """
+
+    def __init__(self):
+        self.inhibited = None  # Attention Children: set to None when not inhibited
+
+    def __del__(self):
+        self.UnInhibit()
+
+    def __enter__(self):
+        self.Inhibit()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.UnInhibit()
+
+    @property
+    def Inhibited(self):
+        return self.inhibited is not None
+
+    def Toggle(self):
+        if not self.Inhibited:
+            self.Inhibit()
+        else:
+            self.UnInhibit()
+
+    @abstractmethod
+    def Inhibit(self):
+        pass
+
+    @abstractmethod
+    def UnInhibit(self):
+        pass
+
 
 class DBusInhibitor(SleepInhibitor):
-	def __init__(self):
-		super().__init__()
-		import dbus
-		self.pm = dbus.SessionBus().get_object("org.freedesktop.PowerManagement", "/org/freedesktop/PowerManagement/Inhibit")
-		
-	def Inhibit(self):
-		if not self.Inhibited:
-			self.inhibited = self.pm.Inhibit("Espresso", "Inhibited by user")
-	
-	def UnInhibit(self):
-		if self.Inhibited:
-			self.pm.UnInhibit(self.inhibited)
-			self.inhibited = None
+    def __init__(self):
+        super().__init__()
+        import dbus
+        self.pm = dbus.SessionBus().get_object("org.freedesktop.PowerManagement", "/org/freedesktop/PowerManagement/Inhibit")
+
+    def Inhibit(self):
+        if not self.Inhibited:
+            self.inhibited = self.pm.Inhibit("Espresso", "Inhibited by user")
+
+    def UnInhibit(self):
+        if self.Inhibited:
+            self.pm.UnInhibit(self.inhibited)
+            self.inhibited = None
+
 
 class WinInhibitor(SleepInhibitor):
-	# _POWER_REQUEST_TYPE enum from WinNT.h
-	(
-	PowerRequestDisplayRequired,
-	PowerRequestSystemRequired,
-	PowerRequestAwayModeRequired,
-	PowerRequestExecutionRequred, # Windows 8 only
-	) = map(int, range(4))
-	
-	def __init__(self):
-		super().__init__()
-		global ctypes
-		import ctypes
-		self.request = ctypes.windll.kernel32.PowerCreateRequest(None) # todo: reason
-	
-	def Inhibit(self):
-		if not self.Inhibited:
-			result = ctypes.windll.kernel32.PowerSetRequest(self.request, self.PowerRequestSystemRequired)
-			if result != 0: # yes, this function returns 0 on failure
-				self.inhibited = True
-			else:
-				raise OSError(result, "SetPowerRequest() failed")
-			
-	def UnInhibit(self):
-		if self.Inhibited:
-			result = ctypes.windll.kernel32.PowerClearRequest(self.request, self.PowerRequestSystemRequired)
-			if result != 0:
-				self.inhibited = None
-			else:
-				raise OSError(result, "PowerClearRequest() failed")
+    # _POWER_REQUEST_TYPE enum from WinNT.h
+    (
+        PowerRequestDisplayRequired,
+        PowerRequestSystemRequired,
+        PowerRequestAwayModeRequired,
+        PowerRequestExecutionRequred,  # Windows 8 only
+    ) = map(int, range(4))
+
+    def __init__(self):
+        super().__init__()
+        global ctypes
+        import ctypes
+        self.request = ctypes.windll.kernel32.PowerCreateRequest(None)  # todo: reason
+
+    def Inhibit(self):
+        if not self.Inhibited:
+            result = ctypes.windll.kernel32.PowerSetRequest(self.request, self.PowerRequestSystemRequired)
+            if result != 0:  # yes, this function returns 0 on failure
+                self.inhibited = True
+            else:
+                raise OSError(result, "SetPowerRequest() failed")
+
+    def UnInhibit(self):
+        if self.Inhibited:
+            result = ctypes.windll.kernel32.PowerClearRequest(self.request, self.PowerRequestSystemRequired)
+            if result != 0:
+                self.inhibited = None
+            else:
+                raise OSError(result, "PowerClearRequest() failed")

--- a/inhibitors.py
+++ b/inhibitors.py
@@ -12,7 +12,6 @@ from abc import ABCMeta, abstractmethod
 
 
 def AutoSelect():
-	import platform
 	if platform.system() == "Linux":
 		return DBusInhibitor()
 	elif platform.system() == "Windows" and sys.getwindowsversion().build >= 7601:

--- a/inhibitors.py
+++ b/inhibitors.py
@@ -15,8 +15,8 @@ def AutoSelect():
 	import platform
 	if platform.system() == "Linux":
 		return DBusInhibitor()
-	elif platform.system() == "Windows" and sys.getwindowsversion().major >= 6 and sys.getwindowsversion().minor >= 1:
-		return Win7Inhibitor()
+	elif platform.system() == "Windows" and sys.getwindowsversion().build >= 7601:
+		return WinInhibitor()
 	else:
 		raise NotImplementedError("Platform not supported")
 
@@ -82,7 +82,7 @@ class DBusInhibitor(SleepInhibitor):
 			self.pm.UnInhibit(self.inhibited)
 			self.inhibited = None
 
-class Win7Inhibitor(SleepInhibitor):
+class WinInhibitor(SleepInhibitor):
 	# _POWER_REQUEST_TYPE enum from WinNT.h
 	(
 	PowerRequestDisplayRequired,


### PR DESCRIPTION
Now recreated it with 3 commits:

1. Make `def AutoSelect()` compatible with Win10 by using Windows' build version.
2. Deleting a duplicate `import` for `platform` inside `def AutoSelect()` - keeping the gobal one, of course.
3. PEP8ing - Of course not necessary, but I thought it might help more than it harms.

First point addresses #2 